### PR TITLE
`main.jl` to reproduce experiments

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 Louis Bouvier, Guillaume Dalle
+Copyright (c) 2022 Louis Bouvier, Guillaume Dalle, Axel Parmentier, Thibaut Vidal
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "InventoryRoutingLNS"
 uuid = "9bd57249-2adc-458a-9ed8-13930b6156fb"
 authors = ["Louis Bouvier", "Guillaume Dalle", "Axel Parmentier", "Thibaut Vidal"]
-version = "0.1.0"
+version = "0.1.1"
 
 [deps]
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"

--- a/test/main.jl
+++ b/test/main.jl
@@ -1,1 +1,23 @@
-# TODO: fill this
+using DataDeps
+using Gurobi
+using InventoryRoutingLNS
+using Random
+Random.seed!(60)
+
+folder_path = joinpath(datadep"IRP-instances", "instances", "instances")
+list_of_instances = readdir(folder_path)
+
+
+for instance_id in list_of_instances
+    println("Solving instance $instance_id")
+    instance = read_instance_CSV(joinpath(folder_path, instance_id))
+    paper_matheuristic!(
+        instance;
+        n_it_commodity_reinsertion=10,
+        n_it_customer_reinsertion=instance.C,
+        tol=-0.01,
+        time_limit=90.0,
+        verbose=true,
+        optimizer = Gurobi.Optimizer
+    )
+end

--- a/test/main.jl
+++ b/test/main.jl
@@ -7,7 +7,6 @@ Random.seed!(60)
 folder_path = joinpath(datadep"IRP-instances", "instances", "instances")
 list_of_instances = readdir(folder_path)
 
-
 for instance_id in list_of_instances
     println("Solving instance $instance_id")
     instance = read_instance_CSV(joinpath(folder_path, instance_id))
@@ -18,6 +17,6 @@ for instance_id in list_of_instances
         tol=-0.01,
         time_limit=90.0,
         verbose=true,
-        optimizer = Gurobi.Optimizer
+        optimizer=Gurobi.Optimizer,
     )
 end


### PR DESCRIPTION
Added the main.jl file to reproduce the numerical experiments of the paper, running the LNS on the whole dataset of 71 IRP instances with the best hyper parameters found for 90 minutes. To run the benchmark algorithm too, please consider our documentation.